### PR TITLE
Dereference symlinks when creating package bundle

### DIFF
--- a/R/spark_apply_bundle.R
+++ b/R/spark_apply_bundle.R
@@ -40,7 +40,7 @@ spark_apply_bundle <- function(packages = TRUE, base_path = getwd()) {
     dir.create(spark_apply_bundle_path(), recursive = TRUE)
 
   args <- c(
-    "-cf",
+    "-chf",
     packagesTar,
     if (isTRUE(packages)) {
       lapply(.libPaths(), function(e) {


### PR DESCRIPTION
Currently, `spark_apply_bundle` will bundle symlinks, such as those used by `packrat`, as-is. This leads to errors when the resulting bundle is deployed to workers with symlinks intact. Adding `-h` to the `tar` command forces `tar` to dereference symlinks, resulting in the actual package files being bundled and resolving this issue.